### PR TITLE
feat: updated Microsoft365DSC to 1.23.809.1

### DIFF
--- a/ConditionalAccessSamplePolicies/Microsoft365DSCCAGroups/M365TenantConfig.ps1
+++ b/ConditionalAccessSamplePolicies/Microsoft365DSCCAGroups/M365TenantConfig.ps1
@@ -26,7 +26,7 @@ Configuration M365TenantConfig
     }
 
     $OrganizationName = $CredsCredential.UserName.Split('@')[1]
-    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.22.420.1'
+    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.23.809.1'
 
     Node localhost
     {

--- a/ConditionalAccessSamplePolicies/Microsoft365DSCCAPolicies/M365TenantConfig.ps1
+++ b/ConditionalAccessSamplePolicies/Microsoft365DSCCAPolicies/M365TenantConfig.ps1
@@ -26,7 +26,7 @@ Configuration M365TenantConfig
     }
 
     $OrganizationName = $CredsCredential.UserName.Split('@')[1]
-    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.22.420.1'
+    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.23.809.1'
 
     Node localhost
     {
@@ -42,7 +42,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA001-Global-BaseProtection-AllApps-AnyPlatform-BlockNonPersonas";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-AzureServiceAccounts","CA-Persona-GuestAdmins","CA-Persona-Guests","CA-Persona-CorpServiceAccounts","CA-Persona-Externals","CA-Persona-Admins","CA-BreakGlassAccounts","CA-Persona-Global-BaseProtection-Exclusions","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-Internals");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -51,7 +50,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "3e53010c-a9c7-4230-bc12-de24eda63f46";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -77,7 +75,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA002-Global-AttackSurfaceReduction-VariousApps-AnyPlatform-Block";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @();
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -86,7 +83,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "7f2437de-1a67-4baa-8a5d-fd6a235288d4";
             IncludeApplications                      = @("None");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -112,7 +108,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA100-Admins-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Admins-BaseProtection-Exclusions","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -121,7 +116,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "99b56601-10cc-4706-8b5b-3479ef3b0f4f";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -147,7 +141,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA101-Admins-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-CorpServiceAccounts","CA-Persona-Admins-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -156,7 +149,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "9646b0dd-302d-4f8b-a100-fd0a268dca18";
             IncludeApplications                      = @();
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -182,7 +174,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA102-Admins-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforMediumandHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-BreakGlassAccounts","CA-Persona-Admins-IdentityProtection-Exclusions","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -191,7 +182,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "AND";
             Id                                       = "29d61290-8fd1-4923-b937-25166009a4f4";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -217,7 +207,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA103-Admins-IdentityProtection-AllApps-AnyPlatform-MFAforMediumandHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-Admins-IdentityProtection-Exclusions","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -226,7 +215,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "d695b04f-1f3b-4ad0-a17a-c9a4314be67a";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -252,7 +240,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA104-Admins-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-Admins-IdentityProtection-Exclusions","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -261,7 +248,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "34fb5388-591a-4cac-92bb-5c8d7423c17d";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -287,7 +273,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA105-Admins-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-Admins-AppProtection-Exclusions","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -296,7 +281,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "3b05a800-be5e-4244-820d-d8078d6ed1b1";
             IncludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -322,7 +306,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA106-Admins-DataProtection-AllApps-iOSorAndroid-ClientAppandAPP";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Admins-DataProtection-Exclusions","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -331,7 +314,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "f8da41f4-6503-4aaa-9635-afd8928ad462";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("android","iOS");
@@ -357,7 +339,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA107-Admins-DataProtection-AllApps-AnyPlatform-SessionPolicy";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Admins-DataProtection-Exclusions","CA-Persona-AzureServiceAccounts","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -365,7 +346,6 @@ Configuration M365TenantConfig
             ExcludeUsers                             = @();
             Id                                       = "a427c2b2-004b-4c71-8b8a-a200357328ab";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -392,7 +372,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA108-Admins-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Microsoft365ServiceAccounts","CA-Persona-AzureServiceAccounts","CA-Persona-Admins-AttackSurfaceReduction-Exclusions","CA-Persona-CorpServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @("android","iOS","windows","windowsPhone","macOS","linux");
@@ -401,7 +380,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "ef5c008e-5531-4926-8091-3f4f9c4873fa";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Admins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -427,7 +405,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA200-Internals-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-BaseProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -436,7 +413,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "9ae17a00-e7b9-4cde-afde-35bd2847a605";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -462,7 +438,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA201-Internals-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -471,7 +446,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "2114e5cb-0391-42c9-82f5-e0b6728803bd";
             IncludeApplications                      = @();
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -497,7 +471,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA202-Internals-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -506,7 +479,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "AND";
             Id                                       = "e41f5940-de1a-41fb-ad85-97257bbee407";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -532,7 +504,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA203-Internals-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -541,7 +512,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "363db5da-09cd-4bc1-b408-1256ebf9891d";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -567,7 +537,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA204-Internals-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -576,7 +545,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "b1f05d88-a0ea-49d5-be5c-33efa51e0599";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -602,7 +570,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA205-Internals-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-AppProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -611,7 +578,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "798038cb-95d1-4d6e-81d5-50273a283c61";
             IncludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -637,7 +603,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA206-Internals-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Internals-AppProtection-Exclusions","CA-Persona-Internals-DataProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -646,7 +611,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "5ddd39c2-22e8-428b-a363-db283a788c1e";
             IncludeApplications                      = @("Office365");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("android","iOS");
@@ -672,7 +636,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA207-Internals-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @();
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @("android","iOS","windows","macOS","linux");
@@ -681,7 +644,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "1ad96a57-cf16-4c9d-b7b3-ba4e72d8d4ab";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Internals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -707,7 +669,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA300-Externals-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-BaseProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -716,7 +677,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "8931fd69-f3cb-4d11-9b7b-4d3f115e3d10";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -742,7 +702,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA301-Externals-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -751,7 +710,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "11e8d17d-8639-4f89-b64a-7c58726e75ac";
             IncludeApplications                      = @();
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -777,7 +735,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA302-Externals-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -786,7 +743,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "07a1ec19-f675-447c-864f-c1379265e470";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -812,7 +768,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA303-Externals-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -821,7 +776,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "cf2f625c-626c-44bb-b080-9efbeae89672";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -847,7 +801,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA304-Externals-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -856,7 +809,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "65038464-4ae8-4b8c-b1f3-56f5d4b76999";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -882,7 +834,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA305-Externals-AppProtection-MicrosoftIntuneEnrollment-MFA";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-AppProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -891,7 +842,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "dd3c3c51-6766-440c-a783-20566b371e3c";
             IncludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -917,7 +867,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA306-Externals-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-AppProtection-Exclusions","CA-Persona-Externals-DataProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -926,7 +875,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "34dae461-7bcd-48dc-ba06-8a3e9bca542c";
             IncludeApplications                      = @("Office365");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("android","iOS");
@@ -952,7 +900,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA307-Externals-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Externals-AttackSurfaceReduction-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @("android","iOS","windows","macOS","linux");
@@ -961,7 +908,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "5b1f1637-c7e0-43f3-9228-f7a69bc296f4";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Externals");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -987,7 +933,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA402-Guests-IdentityProtection-AllApps-AnyPlatform-MFAforMediumandHighUserandSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Guests-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -996,7 +941,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "3e1087c3-083e-4916-8268-94060e42a8a0";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1022,7 +966,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA403-Guests-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Guests-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1031,7 +974,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "566b1228-a8cf-446c-838c-0c9950f638a3";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1057,7 +999,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA404-Guests-AttackSurfaceReduction-AllApps-AnyPlatform-BlockGuestAppAccess";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("Office365");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Guests-AttackSurfaceReduction-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1066,7 +1007,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "1b3bc8ab-71da-4364-9057-b325cb8f28cd";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1092,7 +1032,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA500-GuestAdmins-BaseProtection-AllApps-AnyPlatform-MFA";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-GuestAdmins");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1101,7 +1040,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "cabcface-763d-410d-a096-97a14267304f";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1127,7 +1065,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA502-GuestAdmins-IdentityProtection-AllApps-AnyPlatform-MFAforMediumandHighUserandSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-GuestAdmins-IdentityProtection-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1136,7 +1073,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "fb067dc0-efd2-41b5-b612-99dfed715f16";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1162,7 +1098,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA503-GuestAdmins-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-GuestAdmins-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1171,7 +1106,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "bd372bd8-4f5c-438c-a5fb-dc418ac7abab";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1197,7 +1131,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA504-GuestAdmins-AttackSurfaceReduction-AllApps-AnyPlatform-BlockNonO365Access";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("Office365");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @();
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1206,7 +1139,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "c67cf334-003e-4879-92ea-034ccf9d6c37";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1232,7 +1164,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA600-Microsoft365ServiceAccounts-BaseProtection-AllApps-AnyPlatform-BlockUntrustedLocations";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts");
             ExcludeLocations                         = @("AllTrusted");
             ExcludePlatforms                         = @();
@@ -1241,7 +1172,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "8fc7f7da-46dc-4cef-8984-fdbc1b2870cf";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Microsoft365ServiceAccounts");
             IncludeLocations                         = @("All");
             IncludePlatforms                         = @();
@@ -1267,7 +1197,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA604-Microsoft365ServiceAccounts-AttackSurfaceReduction-O365-AnyPlatform-BlockNonO365";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("Office365");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1276,7 +1205,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "b180a6e7-959a-408f-9d27-c0527626e803";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Microsoft365ServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1302,7 +1230,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA700-AzureServiceAccounts-BaseProtection-AllApps-AnyPlatform-BlockUntrustedLocations";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-AzureServiceAccounts-Exclusions");
             ExcludeLocations                         = @("AllTrusted");
             ExcludePlatforms                         = @();
@@ -1311,7 +1238,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "49b7156d-54af-400a-94da-f2d5d9904cf6";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-AzureServiceAccounts");
             IncludeLocations                         = @("All");
             IncludePlatforms                         = @("all");
@@ -1337,7 +1263,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA704-AzureServiceAccounts-AttackSurfaceReduction-AllApps-AnyPlatform-BlockNonAzure";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("797f4846-ba00-4fd7-ba43-dac1f8f63013");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-AzureServiceAccounts-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1346,7 +1271,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "277028ff-a351-456c-a65d-c1c79dee2408";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-AzureServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1372,7 +1296,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA800-CorpServiceAccounts-BaseProtection-AllApps-AnyPlatform-BlockUntrustedLocations";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-CorpServiceAccounts-Exclusions");
             ExcludeLocations                         = @("AllTrusted");
             ExcludePlatforms                         = @();
@@ -1381,7 +1304,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "d0a2cf7b-6c43-4ec7-a259-95e1a388338b";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-CorpServiceAccounts");
             IncludeLocations                         = @("All");
             IncludePlatforms                         = @("all");
@@ -1407,7 +1329,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA804-CorpServiceAccounts-AttackSurfaceReduction-AllApps-AnyPlatform-BlockNonO365andAzure";
             Ensure                                   = "Present";
             ExcludeApplications                      = @("Office365");
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-CorpServiceAccounts-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1416,7 +1337,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "cfdbaa3d-c28e-42b0-a3d7-04ec4f8dbc7b";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-CorpServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1442,7 +1362,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA401-Guests-IdentityProtection-AllApps-AnyPlatform-TOU-CombinedRegistration";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-GuestAdmins-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1451,7 +1370,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "0855b278-a4cc-448c-8efe-ef1a9b481af1";
             IncludeApplications                      = @();
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1477,7 +1395,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA501-GuestAdmins-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-GuestAdmins-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1486,7 +1403,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "469189c5-2e1a-4851-b333-831357842f7f";
             IncludeApplications                      = @();
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -1513,7 +1429,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA405-Guests-ComplianceProtection-AllApps-AnyPlatform-RequireTOU";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-Guests-Compliance-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1522,7 +1437,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "d21ddea3-49f8-4d41-afbb-dd1ede4c37c5";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1550,7 +1464,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA406-Guests-DataProtection-AllApps-AnyPlatform-SignInSessionPolicy";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccount","CA-Persona-Guests-DataProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1558,7 +1471,6 @@ Configuration M365TenantConfig
             ExcludeUsers                             = @();
             Id                                       = "16aa3b43-b03f-4e16-9172-e13391cd5f91";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Guests");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1585,7 +1497,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA505-GuestAdmins-ComplianceProtection-AnyPlatform-RequireTOU";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Guests-Compliance-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1594,7 +1505,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "b3bd1808-0316-47ac-a02c-e159340287de";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1622,7 +1532,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA506-GuestAdmins-DataProtection-AllApps-AnyPlatform-SignInSessionPolicy";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccount","CA-Persona-GuestAdmins-DataProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1630,7 +1539,6 @@ Configuration M365TenantConfig
             ExcludeUsers                             = @();
             Id                                       = "700c5cdc-c4d2-4c37-abca-abc4dc00c3c1";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-GuestAdmins");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1657,7 +1565,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA601-Microsoft365ServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1666,7 +1573,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "56ad5cff-9efe-4adb-8539-3608ae3cfab1";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Microsoft365ServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1692,7 +1598,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA701-AzureServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-AzureServiceAccounts-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1701,7 +1606,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "a274b074-2138-4f97-b589-888451a188a8";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-AzureServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1727,7 +1631,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA801-CorpServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-CorpServiceAccounts-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1736,7 +1639,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "681a4b42-207b-4236-aaba-6b7be1b5ef57";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-CorpServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1763,7 +1665,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA900-WorkloadIdentities-BaseProtection-AllApps-AnyPlatform-BlockUntrustedLocations";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-WorkloadIdentities-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @("AllTrusted");
             ExcludePlatforms                         = @();
@@ -1772,7 +1673,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "d1fc858f-96ed-4d04-873c-2d15cb5ad465";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-WorkloadIdentities");
             IncludeLocations                         = @("All");
             IncludePlatforms                         = @();
@@ -1798,7 +1698,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1000-Developers-BaseProtection-AllApps-AnyPlatform-ForwardToDefenderforCloudApps";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-BaseProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1806,7 +1705,6 @@ Configuration M365TenantConfig
             ExcludeUsers                             = @();
             Id                                       = "d1b792d9-8d92-4dd8-bc4d-08d062e85934";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1832,7 +1730,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1001-Developers-BaseProtection-AllApps-AnyPlatform-MFAfromUnamagedDevices";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-BaseProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1841,7 +1738,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "19bd434b-0ee6-4d02-9ed1-15d0301af466";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1867,7 +1763,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1002-Developers-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1876,7 +1771,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "fb99d0ef-7279-42a7-84d9-4780ae5f0580";
             IncludeApplications                      = @();
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1902,7 +1796,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1003-Developers-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1911,7 +1804,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "AND";
             Id                                       = "f0bde400-47e4-4fb0-b720-f73f412ee6c5";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1937,7 +1829,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1004-Developers-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-IdentityProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1946,7 +1837,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "e136f350-9639-4f98-b45d-31319e526629";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -1972,7 +1862,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1005-Developers-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-Developers-IdentityProtection-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -1981,7 +1870,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "6431c65c-d7f6-40bf-8a56-4afa1b2bab16";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2007,7 +1895,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1006-Developers-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-AppProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2016,7 +1903,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "f3e7f37e-4034-406f-ab87-ad88dfdecd79";
             IncludeApplications                      = @("d4ebce55-015a-49b5-a083-c84d1797ae8c");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2042,7 +1928,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1007-Developers-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-AppProtection-Exclusions","CA-Persona-Developers-DataProtection-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2051,7 +1936,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "a6928a84-2882-47a1-b608-19e2566c7b24";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("android","iOS");
@@ -2077,7 +1961,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA1008-Developers-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Developers-AttackSurfaceReduction-Exclusions");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @("android","iOS","windows","macOS","linux");
@@ -2086,7 +1969,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "cc92e749-0b45-4d69-8da5-7b9873ca8826";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Developers");
             IncludeLocations                         = @();
             IncludePlatforms                         = @("all");
@@ -2112,7 +1994,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA400-Guests-BaseProtection-AllApps-AnyPlatform-MFA";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @();
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2121,7 +2002,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "8e19f8a3-de9a-4c13-88ea-95adc851c074";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2148,7 +2028,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA602-Microsoft365ServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-Microsoft365ServiceAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2157,7 +2036,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "f9310e9a-843e-4635-b74c-ce0054f17514";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Microsoft365ServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2183,7 +2061,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA603-Microsoft365ServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @();
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2192,7 +2069,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "90caac36-cf70-409f-bb95-7c1ff8f9c6c9";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-Microsoft365ServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2218,7 +2094,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA702-AzureServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-BreakGlassAccounts","CA-Persona-AzureServiceAccounts-Exclusions");
             ExcludeLocations                         = @("AllTrusted");
             ExcludePlatforms                         = @();
@@ -2227,7 +2102,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "856b8034-cae5-4b54-847f-cec68017a820";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-AzureServiceAccounts");
             IncludeLocations                         = @("All");
             IncludePlatforms                         = @();
@@ -2253,7 +2127,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA703-AzureServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-AzureServiceAccounts-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @("AllTrusted");
             ExcludePlatforms                         = @();
@@ -2262,7 +2135,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "57d1c610-7668-43a8-8a29-f7a51c132de9";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-AzureServiceAccounts");
             IncludeLocations                         = @("All");
             IncludePlatforms                         = @();
@@ -2288,7 +2160,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA802-CorpServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockHighUserRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-CorpServiceAccounts-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2297,7 +2168,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "9e7a9a24-9323-4858-8093-27d4aa76ad83";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-CorpServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2323,7 +2193,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA803-CorpServiceAccounts-IdentityProtection-AllApps-AnyPlatform-BlockHighSignInRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @("CA-Persona-CorpServiceAccounts-Exclusions","CA-BreakGlassAccounts");
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2332,7 +2201,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "6439546b-7f65-4f8b-aef4-f1fa67e37f96";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @("CA-Persona-CorpServiceAccounts");
             IncludeLocations                         = @();
             IncludePlatforms                         = @();
@@ -2358,7 +2226,6 @@ Configuration M365TenantConfig
             DisplayName                              = "CA901-WorkloadIdentities-BaseProtection-AllApps-AnyPlatform-BlockHighRisk";
             Ensure                                   = "Present";
             ExcludeApplications                      = @();
-            ExcludeDevices                           = @();
             ExcludeGroups                            = @();
             ExcludeLocations                         = @();
             ExcludePlatforms                         = @();
@@ -2367,7 +2234,6 @@ Configuration M365TenantConfig
             GrantControlOperator                     = "OR";
             Id                                       = "78f8f1d7-98ff-42b1-a276-471632be9ff9";
             IncludeApplications                      = @("All");
-            IncludeDevices                           = @();
             IncludeGroups                            = @();
             IncludeLocations                         = @();
             IncludePlatforms                         = @();


### PR DESCRIPTION
This PR updates Microsoft365DSC dependency to 1.23.809.1 (latest release) and removes deprecated IncludedDevices and ExcludedDevices parameters from Policies script, that were removed in 1.23.405.1 (https://github.com/microsoft/Microsoft365DSC/blob/eed60020e389bfa6c1e53b3a981eef7ce1fcc788/CHANGELOG.md?plain=1#L485)